### PR TITLE
remove static cache objects

### DIFF
--- a/crypto/bsslmlkem/mlkem768.c
+++ b/crypto/bsslmlkem/mlkem768.c
@@ -23,14 +23,6 @@
 # include <stdio.h>
 #endif
 
-/*
- * Set/unset to test performance impact of cached SHA3 EVP_MD instances
- * Impact on x64: everything about 8% slower if un-set
- * TODO(ML-KEM): Remove define if satisfied with approach (API impact)
- * removal will also fix style-related problem
- */
-#define USE_SHA3_CACHE 1
-
 #ifndef OPENSSL_NO_MLKEM
 
 /* Constants that are common across all sizes. */
@@ -171,23 +163,6 @@ void ossl_mlkem_ctx_free(ossl_mlkem_ctx *ctx)
 }
 
 /*
- * TODO(ML-KEM): ctx validation: Is this over the top checking an input
- * construction of which has been checked before? But a malign user
- * could cause problems changing the struct before passing it back
- * Problem: This costs a discernible level of performance (~3%)
- */
-static int validate_mlkem_ctx(ossl_mlkem_ctx *ctx)
-{
-    if (ctx == NULL
-        || ctx->shake128_cache == NULL
-        || ctx->shake256_cache == NULL
-        || ctx->sha3_256_cache == NULL
-        || ctx->sha3_512_cache == NULL)
-        return 0;
-
-    return 1;
-}
-/*
  * single_keccak hashes |in_len| bytes from |in| and writes |out_len| bytes
  * of output to |out|. If the |md| specifies a fixed-output function, like
  * SHA3-256, then |out_len| must be the correct length for that function.
@@ -242,11 +217,7 @@ static void print_hex(const uint8_t *data, int len, const char *msg)
 static void prf(uint8_t *out, size_t out_len, const uint8_t in[33],
                 ossl_mlkem_ctx *mlkem_ctx)
 {
-# ifdef USE_SHA3_CACHE
     single_keccak(out, out_len, in, 33, mlkem_ctx->shake256_cache);
-# else
-    single_keccak(out, out_len, in, 33, EVP_MD_fetch(NULL, "SHAKE256", NULL));
-# endif
 }
 
 /*
@@ -256,22 +227,14 @@ static void prf(uint8_t *out, size_t out_len, const uint8_t in[33],
 static void hash_h(uint8_t *out, const uint8_t *in, size_t len,
                    ossl_mlkem_ctx *mlkem_ctx)
 {
-# ifdef USE_SHA3_CACHE
     single_keccak(out, 32, in, len, mlkem_ctx->sha3_256_cache);
-# else
-    single_keccak(out, 32, in, len, EVP_MD_fetch(NULL, "SHA3-256", NULL));
-# endif
 }
 
 /* uint8_t out[64] */
 static void hash_g(uint8_t *out, const uint8_t *in, size_t len,
                    ossl_mlkem_ctx *mlkem_ctx)
 {
-# ifdef USE_SHA3_CACHE
     single_keccak(out, 64, in, len, mlkem_ctx->sha3_512_cache);
-# else
-    single_keccak(out, 64, in, len, EVP_MD_fetch(NULL, "SHA3-512", NULL));
-# endif
 }
 
 /*
@@ -289,11 +252,7 @@ static int kdf(uint8_t *out,
 
     mdctx = EVP_MD_CTX_new();
     if (mdctx == NULL
-# ifdef USE_SHA3_CACHE
         || !EVP_DigestInit_ex(mdctx, mlkem_ctx->shake256_cache, NULL)
-# else
-        || !EVP_DigestInit_ex(mdctx, EVP_MD_fetch(NULL, "SHAKE256", NULL), NULL)
-# endif
         || !EVP_DigestUpdate(mdctx, failure_secret, 32)
         || !EVP_DigestUpdate(mdctx, ciphertext, ciphertext_len)
         || !EVP_DigestFinalXOF(mdctx, out, OSSL_MLKEM768_SHARED_SECRET_BYTES))
@@ -685,11 +644,7 @@ static int matrix_expand(matrix *out, const uint8_t rho[32],
         for (j = 0; j < RANK768; j++) {
             input[32] = i;
             input[33] = j;
-# ifdef USE_SHA3_CACHE
             if (!EVP_DigestInit_ex(mdctx, mlkem_ctx->shake128_cache, NULL)
-# else
-            if (!EVP_DigestInit_ex(mdctx, EVP_MD_fetch(NULL, "SHAKE128", NULL), NULL)
-# endif
                 || !EVP_DigestUpdate(mdctx, input, sizeof(input))
                 || !scalar_from_keccak_vartime(&out->v[i][j], mdctx))
                 goto end;
@@ -974,7 +929,7 @@ static int mlkem_generate_key_external_seed(uint8_t *out_encoded_public_key,
     uint8_t counter = 0;
     vector error;
 
-    if (!validate_mlkem_ctx(mlkem_ctx))
+    if (mlkem_ctx == NULL)
         return 0;
 
     memcpy(augmented_seed, seed, 32);
@@ -1136,7 +1091,7 @@ int ossl_mlkem768_encap(uint8_t *out_ciphertext,
 {
     uint8_t entropy[MLKEM_ENCAP_ENTROPY];
 
-    if (!validate_mlkem_ctx(mlkem_ctx))
+    if (mlkem_ctx == NULL)
         return 0;
 
     RAND_bytes(entropy, MLKEM_ENCAP_ENTROPY);
@@ -1183,7 +1138,7 @@ static int mlkem_decap(uint8_t *out_shared_secret,
     uint8_t mask;
     int i;
 
-    if (!validate_mlkem_ctx(mlkem_ctx))
+    if (mlkem_ctx == NULL)
         return 0;
 
     print_hex((uint8_t *)&priv->pub, sizeof(ossl_mlkem768_public_key), "PK1");

--- a/crypto/bsslmlkem/mlkem768.c
+++ b/crypto/bsslmlkem/mlkem768.c
@@ -23,6 +23,14 @@
 # include <stdio.h>
 #endif
 
+/*
+ * Set/unset to test performance impact of cached SHA3 EVP_MD instances
+ * Impact on x64: everything about 8% slower if un-set
+ * TODO(ML-KEM): Remove define if satisfied with approach (API impact)
+ * removal will also fix style-related problem
+ */
+#define USE_SHA3_CACHE 1
+
 #ifndef OPENSSL_NO_MLKEM
 
 /* Constants that are common across all sizes. */
@@ -108,17 +116,15 @@ static size_t encoded_public_key_size(int rank)
 
 /* MD&XOF handles */
 
-/* TODO(ML-KEM): enhance as per https://github.com/openssl/private/issues/700 */
+/* Cache mgmt as per https://github.com/openssl/private/issues/700 */
 
-static EVP_MD *shake128_cache = NULL;
-static EVP_MD *shake256_cache = NULL;
-static EVP_MD *sha3_256_cache = NULL;
-static EVP_MD *sha3_512_cache = NULL;
-
-static int mlkem_init(void)
+ossl_mlkem_ctx *ossl_mlkem_newctx(OSSL_LIB_CTX *libctx, const char *properties)
 {
+    ossl_mlkem_ctx *nctx = OPENSSL_zalloc(sizeof(ossl_mlkem_ctx));
+
     /* replacing static asserts: */
-    if ((OSSL_MLKEM768_SHARED_SECRET_BYTES != 32)
+    if (nctx == NULL
+        || (OSSL_MLKEM768_SHARED_SECRET_BYTES != 32)
         || (sizeof(unsigned int) < sizeof (uint32_t))
         || (sizeof(struct ossl_mlkem768_public_key) <
             sizeof(struct public_key_RANK768))
@@ -128,23 +134,59 @@ static int mlkem_init(void)
         || (encoded_public_key_size(RANK1024) != OSSL_MLKEM1024_PUBLIC_KEY_BYTES)
         || (ciphertext_size(RANK768) != OSSL_MLKEM768_CIPHERTEXT_BYTES)
         || (ciphertext_size(RANK1024) != OSSL_MLKEM1024_CIPHERTEXT_BYTES))
-        return 0;
+        goto err;
 
-    if (shake128_cache == NULL || shake256_cache == NULL ||
-        sha3_256_cache == NULL || sha3_512_cache == NULL) {
-        shake128_cache = EVP_MD_fetch(NULL, "SHAKE128", NULL);
-        shake256_cache = EVP_MD_fetch(NULL, "SHAKE256", NULL);
-        sha3_256_cache = EVP_MD_fetch(NULL, "SHA3-256", NULL);
-        sha3_512_cache = EVP_MD_fetch(NULL, "SHA3-512", NULL);
-        if (shake128_cache == NULL || shake256_cache == NULL ||
-            sha3_256_cache == NULL || sha3_512_cache == NULL) {
-            ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
-            return 0;
-        }
-    }
-    return 1;
+    nctx->shake128_cache = EVP_MD_fetch(libctx, "SHAKE128", properties);
+    nctx->shake256_cache = EVP_MD_fetch(libctx, "SHAKE256", properties);
+    nctx->sha3_256_cache = EVP_MD_fetch(libctx, "SHA3-256", properties);
+    nctx->sha3_512_cache = EVP_MD_fetch(libctx, "SHA3-512", properties);
+    nctx->libctx = libctx;
+    if (properties != NULL)
+        nctx->properties = OPENSSL_strdup(properties);
+    if (nctx->shake128_cache == NULL || nctx->shake256_cache == NULL ||
+        nctx->sha3_256_cache == NULL || nctx->sha3_512_cache == NULL)
+        goto err;
+    return nctx;
+
+err:
+    ERR_raise(ERR_LIB_CRYPTO, ERR_R_INTERNAL_ERROR);
+    ossl_mlkem_ctx_free(nctx);
+    return NULL;
 }
 
+void ossl_mlkem_ctx_free(ossl_mlkem_ctx *ctx)
+{
+    if (ctx != NULL) {
+        if (ctx->shake128_cache != NULL)
+            EVP_MD_free(ctx->shake128_cache);
+        if (ctx->shake256_cache != NULL)
+            EVP_MD_free(ctx->shake256_cache);
+        if (ctx->sha3_256_cache != NULL)
+            EVP_MD_free(ctx->sha3_256_cache);
+        if (ctx->sha3_512_cache != NULL)
+            EVP_MD_free(ctx->sha3_512_cache);
+        OPENSSL_free(ctx->properties);
+    }
+    OPENSSL_free(ctx);
+}
+
+/*
+ * TODO(ML-KEM): ctx validation: Is this over the top checking an input
+ * construction of which has been checked before? But a malign user
+ * could cause problems changing the struct before passing it back
+ * Problem: This costs a discernible level of performance (~3%)
+ */
+static int validate_mlkem_ctx(ossl_mlkem_ctx *ctx)
+{
+    if (ctx == NULL
+        || ctx->shake128_cache == NULL
+        || ctx->shake256_cache == NULL
+        || ctx->sha3_256_cache == NULL
+        || ctx->sha3_512_cache == NULL)
+        return 0;
+
+    return 1;
+}
 /*
  * single_keccak hashes |in_len| bytes from |in| and writes |out_len| bytes
  * of output to |out|. If the |md| specifies a fixed-output function, like
@@ -197,24 +239,39 @@ static void print_hex(const uint8_t *data, int len, const char *msg)
 # define MLKEM_ENCAP_ENTROPY 32
 
 /* See https://csrc.nist.gov/pubs/fips/203/final */
-static void prf(uint8_t *out, size_t out_len, const uint8_t in[33])
+static void prf(uint8_t *out, size_t out_len, const uint8_t in[33],
+                ossl_mlkem_ctx *mlkem_ctx)
 {
-    single_keccak(out, out_len, in, 33, shake256_cache);
+# ifdef USE_SHA3_CACHE
+    single_keccak(out, out_len, in, 33, mlkem_ctx->shake256_cache);
+# else
+    single_keccak(out, out_len, in, 33, EVP_MD_fetch(NULL, "SHAKE256", NULL));
+# endif
 }
 
 /*
  * Section 4.1
  * uint8_t out[32]
  */
-static void hash_h(uint8_t *out, const uint8_t *in, size_t len)
+static void hash_h(uint8_t *out, const uint8_t *in, size_t len,
+                   ossl_mlkem_ctx *mlkem_ctx)
 {
-    single_keccak(out, 32, in, len, sha3_256_cache);
+# ifdef USE_SHA3_CACHE
+    single_keccak(out, 32, in, len, mlkem_ctx->sha3_256_cache);
+# else
+    single_keccak(out, 32, in, len, EVP_MD_fetch(NULL, "SHA3-256", NULL));
+# endif
 }
 
 /* uint8_t out[64] */
-static void hash_g(uint8_t *out, const uint8_t *in, size_t len)
+static void hash_g(uint8_t *out, const uint8_t *in, size_t len,
+                   ossl_mlkem_ctx *mlkem_ctx)
 {
-    single_keccak(out, 64, in, len, sha3_512_cache);
+# ifdef USE_SHA3_CACHE
+    single_keccak(out, 64, in, len, mlkem_ctx->sha3_512_cache);
+# else
+    single_keccak(out, 64, in, len, EVP_MD_fetch(NULL, "SHA3-512", NULL));
+# endif
 }
 
 /*
@@ -224,14 +281,19 @@ static void hash_g(uint8_t *out, const uint8_t *in, size_t len)
  */
 static int kdf(uint8_t *out,
                const uint8_t *failure_secret, const uint8_t *ciphertext,
-               size_t ciphertext_len)
+               size_t ciphertext_len,
+               ossl_mlkem_ctx *mlkem_ctx)
 {
     EVP_MD_CTX *mdctx;
     int ret = 0;
 
     mdctx = EVP_MD_CTX_new();
     if (mdctx == NULL
-        || !EVP_DigestInit_ex(mdctx, shake256_cache, NULL)
+# ifdef USE_SHA3_CACHE
+        || !EVP_DigestInit_ex(mdctx, mlkem_ctx->shake256_cache, NULL)
+# else
+        || !EVP_DigestInit_ex(mdctx, EVP_MD_fetch(NULL, "SHAKE256", NULL), NULL)
+# endif
         || !EVP_DigestUpdate(mdctx, failure_secret, 32)
         || !EVP_DigestUpdate(mdctx, ciphertext, ciphertext_len)
         || !EVP_DigestFinalXOF(mdctx, out, OSSL_MLKEM768_SHARED_SECRET_BYTES))
@@ -563,7 +625,9 @@ static int scalar_from_keccak_vartime(scalar *out, EVP_MD_CTX *mdctx)
  * and 0 with probability 3/8.
  */
 static
-void scalar_centered_binomial_distribution_eta_2_with_prf(scalar *out, const uint8_t input[33])
+void scalar_centered_binomial_distribution_eta_2_with_prf(scalar *out,
+                                                          const uint8_t input[33],
+                                                          ossl_mlkem_ctx *mlkem_ctx)
 {
     uint8_t entropy[128];
     int i;
@@ -571,7 +635,7 @@ void scalar_centered_binomial_distribution_eta_2_with_prf(scalar *out, const uin
     uint16_t value;
 
     assert(sizeof(entropy) == 2 * /* kEta= */ 2 * DEGREE / 8);
-    prf(entropy, sizeof(entropy), input);
+    prf(entropy, sizeof(entropy), input, mlkem_ctx);
     for (i = 0; i < DEGREE; i += 2) {
         byte = entropy[i / 2];
         value = kPrime;
@@ -592,7 +656,8 @@ void scalar_centered_binomial_distribution_eta_2_with_prf(scalar *out, const uin
  * appending and incrementing |counter| for entry of the vector.
  */
 static void vector_generate_secret_eta_2(vector *out, uint8_t *counter,
-                                         const uint8_t seed[32])
+                                         const uint8_t seed[32],
+                                         ossl_mlkem_ctx *mlkem_ctx)
 {
     uint8_t input[33];
     int i;
@@ -600,12 +665,14 @@ static void vector_generate_secret_eta_2(vector *out, uint8_t *counter,
     memcpy(input, seed, 32);
     for (i = 0; i < RANK768; i++) {
         input[32] = (*counter)++;
-        scalar_centered_binomial_distribution_eta_2_with_prf(&out->v[i], input);
+        scalar_centered_binomial_distribution_eta_2_with_prf(&out->v[i],
+                                                             input, mlkem_ctx);
     }
 }
 
 /* Expands the matrix of a seed for key generation and for encaps-CPA. */
-static int matrix_expand(matrix *out, const uint8_t rho[32])
+static int matrix_expand(matrix *out, const uint8_t rho[32],
+                         ossl_mlkem_ctx *mlkem_ctx)
 {
     uint8_t input[34];
     int i, j, ret = 0;
@@ -618,7 +685,11 @@ static int matrix_expand(matrix *out, const uint8_t rho[32])
         for (j = 0; j < RANK768; j++) {
             input[32] = i;
             input[33] = j;
-            if (!EVP_DigestInit_ex(mdctx, shake128_cache, NULL)
+# ifdef USE_SHA3_CACHE
+            if (!EVP_DigestInit_ex(mdctx, mlkem_ctx->shake128_cache, NULL)
+# else
+            if (!EVP_DigestInit_ex(mdctx, EVP_MD_fetch(NULL, "SHAKE128", NULL), NULL)
+# endif
                 || !EVP_DigestUpdate(mdctx, input, sizeof(input))
                 || !scalar_from_keccak_vartime(&out->v[i][j], mdctx))
                 goto end;
@@ -875,7 +946,8 @@ static int mlkem_marshal_public_key(uint8_t *out,
 }
 
 int ossl_mlkem768_recreate_public_key(const uint8_t *encoded_public_key,
-                                      ossl_mlkem768_public_key *ext_pub)
+                                      ossl_mlkem768_public_key *ext_pub,
+                                      ossl_mlkem_ctx *mlkem_ctx)
 {
     struct public_key_RANK768 *pub = public_key_768_from_external(ext_pub);
 
@@ -883,16 +955,17 @@ int ossl_mlkem768_recreate_public_key(const uint8_t *encoded_public_key,
     if (!vector_decode(&pub->t, encoded_public_key, kLog2Prime))
         return 0;
     memcpy(pub->rho, encoded_public_key + encoded_vector_size(RANK768), sizeof(pub->rho));
-    matrix_expand(&pub->m, pub->rho);
+    matrix_expand(&pub->m, pub->rho, mlkem_ctx);
     hash_h(pub->public_key_hash, encoded_public_key,
-           encoded_public_key_size(RANK768));
+           encoded_public_key_size(RANK768), mlkem_ctx);
     print_hex((uint8_t *)pub, sizeof(public_key_RANK768), "recreated PK");
     return 1;
 }
 
 static int mlkem_generate_key_external_seed(uint8_t *out_encoded_public_key,
                                             private_key_RANK768 *priv,
-                                            const uint8_t *seed)
+                                            const uint8_t *seed,
+                                            ossl_mlkem_ctx *mlkem_ctx)
 {
     uint8_t augmented_seed[33];
     uint8_t hashed[64];
@@ -901,24 +974,24 @@ static int mlkem_generate_key_external_seed(uint8_t *out_encoded_public_key,
     uint8_t counter = 0;
     vector error;
 
-    if (!mlkem_init())
+    if (!validate_mlkem_ctx(mlkem_ctx))
         return 0;
 
     memcpy(augmented_seed, seed, 32);
     augmented_seed[32] = RANK768;
-    hash_g(hashed, augmented_seed, sizeof(augmented_seed));
+    hash_g(hashed, augmented_seed, sizeof(augmented_seed), mlkem_ctx);
     memcpy(priv->pub.rho, hashed, sizeof(priv->pub.rho));
-    matrix_expand(&priv->pub.m, rho);
-    vector_generate_secret_eta_2(&priv->s, &counter, sigma);
+    matrix_expand(&priv->pub.m, rho, mlkem_ctx);
+    vector_generate_secret_eta_2(&priv->s, &counter, sigma, mlkem_ctx);
     vector_ntt(&priv->s);
-    vector_generate_secret_eta_2(&error, &counter, sigma);
+    vector_generate_secret_eta_2(&error, &counter, sigma, mlkem_ctx);
     vector_ntt(&error);
     matrix_mult_transpose(&priv->pub.t, &priv->pub.m, &priv->s);
     vector_add(&priv->pub.t, &error);
     if (!mlkem_marshal_public_key(out_encoded_public_key, &priv->pub))
         abort();
     hash_h(priv->pub.public_key_hash, out_encoded_public_key,
-           encoded_public_key_size(RANK768));
+           encoded_public_key_size(RANK768), mlkem_ctx);
     memcpy(priv->fo_failure_secret, seed + 32, 32);
     return 1;
 }
@@ -926,17 +999,19 @@ static int mlkem_generate_key_external_seed(uint8_t *out_encoded_public_key,
 static
 int ossl_mlkem768_generate_key_external_seed(uint8_t *out_encoded_public_key,
                                              ossl_mlkem768_private_key *out_private_key,
-                                             const uint8_t *seed)
+                                             const uint8_t *seed,
+                                             ossl_mlkem_ctx *mlkem_ctx)
 {
     private_key_RANK768 *priv = NULL;
 
     priv = private_key_768_from_external(out_private_key);
-    return mlkem_generate_key_external_seed(out_encoded_public_key, priv, seed);
+    return mlkem_generate_key_external_seed(out_encoded_public_key, priv, seed, mlkem_ctx);
 }
 
 int ossl_mlkem768_generate_key(uint8_t *out_encoded_public_key,
                                uint8_t *optional_out_seed,
-                               ossl_mlkem768_private_key *out_private_key)
+                               ossl_mlkem768_private_key *out_private_key,
+                               ossl_mlkem_ctx *mlkem_ctx)
 {
     uint8_t seed[MLKEM_SEED_BYTES];
 
@@ -945,17 +1020,19 @@ int ossl_mlkem768_generate_key(uint8_t *out_encoded_public_key,
         memcpy(optional_out_seed, seed, sizeof(seed));
     return ossl_mlkem768_generate_key_external_seed(out_encoded_public_key,
                                                     out_private_key,
-                                                    seed);
+                                                    seed, mlkem_ctx);
 }
 
 int ossl_mlkem768_private_key_from_seed(ossl_mlkem768_private_key *out_private_key,
-                                        const uint8_t *seed, size_t seed_len)
+                                        const uint8_t *seed, size_t seed_len,
+                                        ossl_mlkem_ctx *mlkem_ctx)
 {
     uint8_t public_key_bytes[OSSL_MLKEM768_PUBLIC_KEY_BYTES];
 
     if (seed_len != MLKEM_SEED_BYTES)
         return 0;
-    ossl_mlkem768_generate_key_external_seed(public_key_bytes, out_private_key, seed);
+    ossl_mlkem768_generate_key_external_seed(public_key_bytes, out_private_key,
+                                             seed, mlkem_ctx);
     return 1;
 }
 
@@ -977,7 +1054,8 @@ void ossl_mlkem768_public_from_private(ossl_mlkem768_public_key *out_public_key,
  */
 static void encrypt_cpa(uint8_t *out, const struct public_key_RANK768 *pub,
                         const uint8_t *message,
-                        const uint8_t *randomness)
+                        const uint8_t *randomness,
+                        ossl_mlkem_ctx *mlkem_ctx)
 {
     int du = kDU768;
     int dv = kDV768;
@@ -989,12 +1067,12 @@ static void encrypt_cpa(uint8_t *out, const struct public_key_RANK768 *pub,
     scalar v;
     scalar expanded_message;
 
-    vector_generate_secret_eta_2(&secret, &counter, randomness);
+    vector_generate_secret_eta_2(&secret, &counter, randomness, mlkem_ctx);
     vector_ntt(&secret);
-    vector_generate_secret_eta_2(&error, &counter, randomness);
+    vector_generate_secret_eta_2(&error, &counter, randomness, mlkem_ctx);
     memcpy(input, randomness, 32);
     input[32] = counter;
-    scalar_centered_binomial_distribution_eta_2_with_prf(&scalar_error, input);
+    scalar_centered_binomial_distribution_eta_2_with_prf(&scalar_error, input, mlkem_ctx);
     matrix_mult(&u, &pub->m, &secret);
     vector_inverse_ntt(&u);
     vector_add(&u, &error);
@@ -1017,7 +1095,8 @@ static void encrypt_cpa(uint8_t *out, const struct public_key_RANK768 *pub,
 static void mlkem_encap_external_entropy(uint8_t *out_ciphertext,
                                          uint8_t *out_shared_secret,
                                          const public_key_RANK768 *pub,
-                                         const uint8_t *entropy)
+                                         const uint8_t *entropy,
+                                         ossl_mlkem_ctx *mlkem_ctx)
 {
     uint8_t input[64];
     uint8_t key_and_randomness[64];
@@ -1025,8 +1104,8 @@ static void mlkem_encap_external_entropy(uint8_t *out_ciphertext,
     memcpy(input, entropy, MLKEM_ENCAP_ENTROPY);
     memcpy(input + MLKEM_ENCAP_ENTROPY, pub->public_key_hash,
            sizeof(input) - MLKEM_ENCAP_ENTROPY);
-    hash_g(key_and_randomness, input, sizeof(input));
-    encrypt_cpa(out_ciphertext, pub, entropy, key_and_randomness + 32);
+    hash_g(key_and_randomness, input, sizeof(input), mlkem_ctx);
+    encrypt_cpa(out_ciphertext, pub, entropy, key_and_randomness + 32, mlkem_ctx);
     memcpy(out_shared_secret, key_and_randomness, 32);
 }
 
@@ -1039,27 +1118,30 @@ static
 void ossl_mlkem768_encap_external_entropy(uint8_t *out_ciphertext,
                                           uint8_t *out_shared_secret,
                                           const ossl_mlkem768_public_key *public_key,
-                                          const uint8_t *entropy)
+                                          const uint8_t *entropy,
+                                          ossl_mlkem_ctx *mlkem_ctx)
 {
     const struct public_key_RANK768 *pub =
         public_key_768_from_external(public_key);
 
-    mlkem_encap_external_entropy(out_ciphertext, out_shared_secret, pub, entropy);
+    mlkem_encap_external_entropy(out_ciphertext, out_shared_secret, pub,
+                                 entropy, mlkem_ctx);
 }
 
 /* Calls |ossl_mlkem768_encap_external_entropy| with random bytes from |RAND_bytes| */
 int ossl_mlkem768_encap(uint8_t *out_ciphertext,
                         uint8_t *out_shared_secret,
-                        const ossl_mlkem768_public_key *public_key)
+                        const ossl_mlkem768_public_key *public_key,
+                        ossl_mlkem_ctx *mlkem_ctx)
 {
     uint8_t entropy[MLKEM_ENCAP_ENTROPY];
 
-    if (!mlkem_init())
+    if (!validate_mlkem_ctx(mlkem_ctx))
         return 0;
 
     RAND_bytes(entropy, MLKEM_ENCAP_ENTROPY);
     ossl_mlkem768_encap_external_entropy(out_ciphertext, out_shared_secret, public_key,
-                                         entropy);
+                                         entropy, mlkem_ctx);
     print_hex((uint8_t *)public_key, sizeof(ossl_mlkem768_public_key), "PK");
     print_hex(out_shared_secret, OSSL_MLKEM768_SHARED_SECRET_BYTES, "SS2");
     print_hex(out_ciphertext, OSSL_MLKEM768_CIPHERTEXT_BYTES, "CT2");
@@ -1089,7 +1171,8 @@ static void decrypt_cpa(uint8_t *out, const struct private_key_RANK768 *priv,
 /* See section 6.3 */
 static int mlkem_decap(uint8_t *out_shared_secret,
                        const uint8_t *ciphertext,
-                       const struct private_key_RANK768 *priv)
+                       const struct private_key_RANK768 *priv,
+                       ossl_mlkem_ctx *mlkem_ctx)
 {
     uint8_t decrypted[64];
     uint8_t key_and_randomness[64];
@@ -1100,7 +1183,7 @@ static int mlkem_decap(uint8_t *out_shared_secret,
     uint8_t mask;
     int i;
 
-    if (!mlkem_init())
+    if (!validate_mlkem_ctx(mlkem_ctx))
         return 0;
 
     print_hex((uint8_t *)&priv->pub, sizeof(ossl_mlkem768_public_key), "PK1");
@@ -1108,11 +1191,11 @@ static int mlkem_decap(uint8_t *out_shared_secret,
     decrypt_cpa(decrypted, priv, ciphertext);
     memcpy(decrypted + 32, priv->pub.public_key_hash,
            sizeof(decrypted) - 32);
-    hash_g(key_and_randomness, decrypted, sizeof(decrypted));
+    hash_g(key_and_randomness, decrypted, sizeof(decrypted), mlkem_ctx);
     assert(ciphertext_len <= sizeof(expected_ciphertext));
     encrypt_cpa(expected_ciphertext, &priv->pub, decrypted,
-                key_and_randomness + 32);
-    kdf(failure_key, priv->fo_failure_secret, ciphertext, ciphertext_len);
+                key_and_randomness + 32, mlkem_ctx);
+    kdf(failure_key, priv->fo_failure_secret, ciphertext, ciphertext_len, mlkem_ctx);
     mask = constant_time_eq_int_8(CRYPTO_memcmp(ciphertext,
                                                 expected_ciphertext, ciphertext_len), 0);
     for (i = 0; i < OSSL_MLKEM768_SHARED_SECRET_BYTES; i++)
@@ -1125,7 +1208,8 @@ static int mlkem_decap(uint8_t *out_shared_secret,
 
 int ossl_mlkem768_decap(uint8_t *out_shared_secret,
                         const uint8_t *ciphertext, size_t ciphertext_len,
-                        const ossl_mlkem768_private_key *private_key)
+                        const ossl_mlkem768_private_key *private_key,
+                        ossl_mlkem_ctx *mlkem_ctx)
 {
     const struct private_key_RANK768 *priv;
 
@@ -1134,7 +1218,7 @@ int ossl_mlkem768_decap(uint8_t *out_shared_secret,
         return 0;
     }
     priv = private_key_768_from_external(private_key);
-    return mlkem_decap(out_shared_secret, ciphertext, priv);
+    return mlkem_decap(out_shared_secret, ciphertext, priv, mlkem_ctx);
 }
 
 #endif /* OPENSSL_NO_MLKEM */

--- a/include/crypto/mlkem.h
+++ b/include/crypto/mlkem.h
@@ -14,12 +14,27 @@
 
 # include <stdint.h>
 # include <openssl/e_os2.h>
+# include <crypto/evp.h>
 
 # if defined(__cplusplus)
 extern "C" {
 # endif
 
 # ifndef OPENSSL_NO_MLKEM
+
+    typedef struct ossl_mlkem_ctx {
+        EVP_MD *shake128_cache;
+        EVP_MD *shake256_cache;
+        EVP_MD *sha3_256_cache;
+        EVP_MD *sha3_512_cache;
+        OSSL_LIB_CTX *libctx;
+        char *properties;
+    } ossl_mlkem_ctx;
+
+    /* General ctx functions */
+    ossl_mlkem_ctx *ossl_mlkem_newctx(OSSL_LIB_CTX *libctx, const char *properties);
+
+    void ossl_mlkem_ctx_free(ossl_mlkem_ctx *ctx);
 
     /*
      * TODO: Change void APIs to error-returning APIs,
@@ -32,8 +47,6 @@ extern "C" {
      * This implements the Module-Lattice-Based Key-Encapsulation Mechanism from
      * https://csrc.nist.gov/pubs/fips/203/final
      */
-
-    /* TODO Some style checks fail here; see https://github.com/openssl/private/issues/699 */
 
     /*
      * ossl_mlkem768_public_key contains an ML-KEM-768 public key. The contents of this
@@ -92,7 +105,8 @@ extern "C" {
      */
     int ossl_mlkem768_generate_key(uint8_t *out_encoded_public_key,
                                    uint8_t *optional_out_seed,
-                                   struct ossl_mlkem768_private_key *out_private_key);
+                                   struct ossl_mlkem768_private_key *out_private_key,
+                                   ossl_mlkem_ctx *mlkem_ctx);
 
     /*
      * ossl_mlkem768_private_key_from_seed derives a private key from a seed that was
@@ -101,7 +115,8 @@ extern "C" {
      */
     int ossl_mlkem768_private_key_from_seed(ossl_mlkem768_private_key *out_private_key,
                                             const uint8_t *seed,
-                                            size_t seed_len);
+                                            size_t seed_len,
+                                            ossl_mlkem_ctx *mlkem_ctx);
 
     /*
      * ossl_mlkem768_public_from_private sets |*out_public_key| to the public key that
@@ -130,7 +145,8 @@ extern "C" {
      */
     int ossl_mlkem768_encap(uint8_t *out_ciphertext,
                             uint8_t *out_shared_secret,
-                            const ossl_mlkem768_public_key *public_key);
+                            const ossl_mlkem768_public_key *public_key,
+                            ossl_mlkem_ctx *mlkem_ctx);
 
     /*
      * ossl_mlkem768_decap decrypts a shared secret from |ciphertext| using |private_key|
@@ -146,7 +162,8 @@ extern "C" {
      */
     int ossl_mlkem768_decap(uint8_t *out_shared_secret,
                             const uint8_t *ciphertext, size_t ciphertext_len,
-                            const ossl_mlkem768_private_key *private_key);
+                            const ossl_mlkem768_private_key *private_key,
+                            ossl_mlkem_ctx *mlkem_ctx);
 
     /*
      * ossl_mlkem768_recreate_public_key recreates a fully formed ossl_mlkem768_public_key
@@ -155,7 +172,8 @@ extern "C" {
      * sizeof(ossl_mlkem768_public_key)
      */
     int ossl_mlkem768_recreate_public_key(const uint8_t *encoded_public_key,
-                                          ossl_mlkem768_public_key *pub);
+                                          ossl_mlkem768_public_key *pub,
+                                          ossl_mlkem_ctx *mlkem_ctx);
 
 # endif /* OPENSSL_NO_MLKEM */
 

--- a/providers/implementations/include/prov/mlkem.h
+++ b/providers/implementations/include/prov/mlkem.h
@@ -27,6 +27,8 @@ typedef struct mlkem768_key_st {
     uint8_t *encoded_pubkey;
     int pubkey_initialized;
     int seckey_initialized;
+    ossl_mlkem_ctx *mlkem_ctx;
+    void *provctx;
 } MLKEM768_KEY;
 
 # endif /* OPENSSL_NO_MLKEM */

--- a/providers/implementations/kem/ml_kem.c
+++ b/providers/implementations/kem/ml_kem.c
@@ -61,6 +61,7 @@ static void *mlkem_newctx(void *provctx)
     debug_print("MLKEMKEM newctx called\n");
     if (ctx == NULL)
         return NULL;
+
     ctx->libctx = PROV_LIBCTX_OF(provctx);
 
     debug_print("MLKEMKEM newctx returns %p\n", ctx);
@@ -152,7 +153,7 @@ static int mlkem_encapsulate(void *vctx, unsigned char *out, size_t *outlen,
             || secret == NULL)
         return 0;
 
-    ossl_mlkem768_encap(out, (uint8_t *)secret, &ctx->key->pubkey);
+    ossl_mlkem768_encap(out, (uint8_t *)secret, &ctx->key->pubkey, ctx->key->mlkem_ctx);
 
     debug_print("MLKEMKEM encaps OK\n");
     return 1;
@@ -182,7 +183,8 @@ static int mlkem_decapsulate(void *vctx, unsigned char *out, size_t *outlen,
     if (inlen != OSSL_MLKEM768_CIPHERTEXT_BYTES)
         return 0;
 
-    ossl_mlkem768_decap((uint8_t *)out, (uint8_t *)in, inlen, &ctx->key->seckey);
+    ossl_mlkem768_decap((uint8_t *)out, (uint8_t *)in, inlen, &ctx->key->seckey,
+                        ctx->key->mlkem_ctx);
 
     debug_print("MLKEMKEM decaps OK\n");
     return 1;

--- a/providers/implementations/keymgmt/mlkem_kmgmt.c
+++ b/providers/implementations/keymgmt/mlkem_kmgmt.c
@@ -12,7 +12,6 @@
 #include <openssl/params.h>
 #include <openssl/err.h>
 #include <openssl/proverr.h>
-#include <openssl/evp.h>
 #include <openssl/rand.h>
 #include <openssl/self_test.h>
 #include "internal/param_build_set.h"
@@ -94,10 +93,23 @@ static void *mlkem_new(void *provctx)
     debug_print("MLKEMKM new key req\n");
     if (!ossl_prov_is_running())
         return 0;
+
     key = OPENSSL_zalloc(sizeof(MLKEM768_KEY));
-    if (key == NULL)
-        return 0;
-    key->keytype = MLKEM_KEY_TYPE_768; /* TODO(ML-KEM) any type */
+    if (key != NULL) {
+        key->keytype = MLKEM_KEY_TYPE_768; /* TODO(ML-KEM) any type */
+        key->provctx = provctx;
+        /*
+         * ideally, this is a one-time allocation and ctx that should be within the
+         * provider context: OK to move it there?? It would be the first algorithm-
+         * specific context stored: Feels weird (TODO(ML-KEM)).
+         */
+        key->mlkem_ctx = ossl_mlkem_newctx(provctx == NULL ? NULL : PROV_LIBCTX_OF(provctx), NULL);
+        if (key->mlkem_ctx == NULL) {
+            OPENSSL_free(key);
+            key = NULL;
+        }
+    }
+
     debug_print("MLKEMKM new key = %p\n", key);
     return key;
 }
@@ -109,6 +121,7 @@ static void mlkem_free(void *vkey)
     debug_print("MLKEMKM free key %p\n", mkey);
     if (mkey == NULL)
         return;
+    ossl_mlkem_ctx_free(mkey->mlkem_ctx);
     OPENSSL_free(mkey->encoded_pubkey);
     OPENSSL_free(mkey);
 }
@@ -408,7 +421,8 @@ static int mlkem_set_params(void *key, const OSSL_PARAM params[])
                                                 &len_stored))
             return 0;
         debug_print("encoded pub key successfully stored with %ld bytes\n", len_stored);
-        ossl_mlkem768_recreate_public_key(mkey->encoded_pubkey, &mkey->pubkey);
+        ossl_mlkem768_recreate_public_key(mkey->encoded_pubkey, &mkey->pubkey,
+                                          mkey->mlkem_ctx);
         mkey->pubkey_initialized = 1;
     }
 
@@ -477,7 +491,7 @@ static void *mlkem_gen(void *vctx, OSSL_CALLBACK *osslcb, void *cbarg)
     if (gctx == NULL)
         return NULL;
 
-    if ((mkey = mlkem_new(NULL)) == NULL) {
+    if ((mkey = mlkem_new(gctx->provctx)) == NULL) {
         ERR_raise(ERR_LIB_PROV, ERR_R_INTERNAL_ERROR);
         return NULL;
     }
@@ -498,7 +512,8 @@ static void *mlkem_gen(void *vctx, OSSL_CALLBACK *osslcb, void *cbarg)
         }
     }
 
-    ossl_mlkem768_generate_key(mkey->encoded_pubkey, NULL, &mkey->seckey);
+    ossl_mlkem768_generate_key(mkey->encoded_pubkey, NULL, &mkey->seckey,
+                               mkey->mlkem_ctx);
     mkey->seckey_initialized = 1;
     ossl_mlkem768_public_from_private(&mkey->pubkey, &mkey->seckey);
     mkey->pubkey_initialized = 1;
@@ -524,7 +539,7 @@ static void *mlkem_dup(const void *vsrckey, int selection)
     if (!ossl_prov_is_running())
         return NULL;
 
-    dstkey = mlkem_new(NULL);
+    dstkey = mlkem_new(srckey->provctx);
     if (dstkey == NULL)
         return NULL;
 

--- a/providers/implementations/keymgmt/mlkem_kmgmt.c
+++ b/providers/implementations/keymgmt/mlkem_kmgmt.c
@@ -100,8 +100,8 @@ static void *mlkem_new(void *provctx)
         key->provctx = provctx;
         /*
          * ideally, this is a one-time allocation and ctx that should be within the
-         * provider context: OK to move it there?? It would be the first algorithm-
-         * specific context stored: Feels weird (TODO(ML-KEM)).
+         * provider context: OK to move it there to improve performance?? It would be
+         * the first algorithmspecific context stored: Feels weird (TODO(ML-KEM)).
          */
         key->mlkem_ctx = ossl_mlkem_newctx(provctx == NULL ? NULL : PROV_LIBCTX_OF(provctx), NULL);
         if (key->mlkem_ctx == NULL) {

--- a/test/evp_extra_test.c
+++ b/test/evp_extra_test.c
@@ -5911,6 +5911,109 @@ static int test_invalid_ctx_for_digest(void)
     return ret;
 }
 
+static int test_ml_kem(void)
+{
+    EVP_PKEY *akey, *bkey = NULL;
+    int res = 0;
+    size_t publen;
+    unsigned char *rawpub = NULL;
+    EVP_PKEY_CTX *ctx = NULL;
+    unsigned char *wrpkey = NULL, *agenkey = NULL, *bgenkey = NULL;
+    size_t wrpkeylen, agenkeylen, bgenkeylen, i;
+
+    /* Generate Alice's key */
+    akey = EVP_PKEY_Q_keygen(testctx, NULL, "MLKEM-768");
+    if (!TEST_ptr(akey))
+        goto err;
+
+    /* Get the raw public key */
+    publen = EVP_PKEY_get1_encoded_public_key(akey, &rawpub);
+    if (!TEST_size_t_gt(publen, 0))
+        goto err;
+
+    /* Create Bob's key and populate it with Alice's public key data */
+    bkey = EVP_PKEY_new();
+    if (!TEST_ptr(bkey))
+        goto err;
+
+    if (!TEST_int_gt(EVP_PKEY_copy_parameters(bkey, akey), 0))
+        goto err;
+
+    if (!TEST_true(EVP_PKEY_set1_encoded_public_key(bkey, rawpub, publen)))
+        goto err;
+
+    /* Encapsulate Bob's key */
+    ctx = EVP_PKEY_CTX_new_from_pkey(testctx, bkey, NULL);
+    if (!TEST_ptr(ctx))
+        goto err;
+
+    if (!TEST_int_gt(EVP_PKEY_encapsulate_init(ctx, NULL), 0))
+        goto err;
+
+    if (!TEST_int_gt(EVP_PKEY_encapsulate(ctx, NULL, &wrpkeylen, NULL,
+                                          &bgenkeylen), 0))
+        goto err;
+
+    if (!TEST_size_t_gt(wrpkeylen, 0) || !TEST_size_t_gt(bgenkeylen, 0))
+        goto err;
+
+    wrpkey = OPENSSL_zalloc(wrpkeylen);
+    bgenkey = OPENSSL_zalloc(bgenkeylen);
+    if (!TEST_ptr(wrpkey) || !TEST_ptr(bgenkey))
+        goto err;
+
+    if (!TEST_int_gt(EVP_PKEY_encapsulate(ctx, wrpkey, &wrpkeylen, bgenkey,
+                                          &bgenkeylen), 0))
+        goto err;
+
+    EVP_PKEY_CTX_free(ctx);
+
+    /* Alice now decapsulates Bob's key */
+    ctx = EVP_PKEY_CTX_new_from_pkey(testctx, akey, NULL);
+    if (!TEST_ptr(ctx))
+        goto err;
+
+    if (!TEST_int_gt(EVP_PKEY_decapsulate_init(ctx, NULL), 0))
+        goto err;
+
+    if (!TEST_int_gt(EVP_PKEY_decapsulate(ctx, NULL, &agenkeylen, wrpkey,
+                                          wrpkeylen), 0))
+        goto err;
+
+    if (!TEST_size_t_gt(agenkeylen, 0))
+        goto err;
+
+    agenkey = OPENSSL_zalloc(agenkeylen);
+    if (!TEST_ptr(agenkey))
+        goto err;
+
+    if (!TEST_int_gt(EVP_PKEY_decapsulate(ctx, agenkey, &agenkeylen, wrpkey,
+                                          wrpkeylen), 0))
+        goto err;
+
+    /* Hopefully we ended up with a shared key */
+    if (!TEST_mem_eq(agenkey, agenkeylen, bgenkey, bgenkeylen))
+        goto err;
+
+    /* Verify we generated a non-zero shared key */
+    for (i = 0; i < agenkeylen; i++)
+        if (agenkey[i] != 0)
+            break;
+    if (!TEST_size_t_ne(i, agenkeylen))
+        return 0;
+
+    res = 1;
+ err:
+    EVP_PKEY_CTX_free(ctx);
+    EVP_PKEY_free(akey);
+    EVP_PKEY_free(bkey);
+    OPENSSL_free(rawpub);
+    OPENSSL_free(wrpkey);
+    OPENSSL_free(agenkey);
+    OPENSSL_free(bgenkey);
+    return res;
+}
+
 int setup_tests(void)
 {
     char *config_file = NULL;
@@ -6095,6 +6198,7 @@ int setup_tests(void)
 #endif
 
     ADD_TEST(test_invalid_ctx_for_digest);
+    ADD_TEST(test_ml_kem);
 
     return 1;
 }

--- a/test/mlkem_internal_test.c
+++ b/test/mlkem_internal_test.c
@@ -31,39 +31,56 @@ int main(void)
     ossl_mlkem768_public_key public_key;
     ossl_mlkem768_public_key recreated_public_key;
     uint8_t *p1, *p2;
+    ossl_mlkem_ctx *mlkem_ctx = ossl_mlkem_newctx(NULL, NULL);
+    int ret = 1;
 
     /* enable TEST_* API */
     test_open_streams();
 
     /* first, generate a key pair */
-    if (!ossl_mlkem768_generate_key(out_encoded_public_key, NULL, &private_key))
-        return 1;
+    if (!ossl_mlkem768_generate_key(out_encoded_public_key, NULL,
+                                    &private_key, mlkem_ctx)) {
+        ret = -1;
+        goto end;
+    }
     /* public key component to be created from private key */
     ossl_mlkem768_public_from_private(&public_key, &private_key);
     /* try to re-create public key structure from encoded public key */
-    ossl_mlkem768_recreate_public_key(out_encoded_public_key, &recreated_public_key);
+    ossl_mlkem768_recreate_public_key(out_encoded_public_key, &recreated_public_key, mlkem_ctx);
     /* validate identity of both public key structures */
     p1 = (uint8_t *)&public_key;
     p2 = (uint8_t *)&recreated_public_key;
-    if (!TEST_int_eq(memcmp(p1, p2, sizeof(public_key)), 0))
-        return 2;
+    if (!TEST_int_eq(memcmp(p1, p2, sizeof(public_key)), 0)) {
+        ret = -2;
+        goto end;
+    }
     /* encaps - decaps test: validate shared secret identity */
-    if (!ossl_mlkem768_encap(out_ciphertext, out_shared_secret, &recreated_public_key))
-        return 3;
+    if (!ossl_mlkem768_encap(out_ciphertext, out_shared_secret,
+                             &recreated_public_key, mlkem_ctx)) {
+        ret = -3;
+        goto end;
+    }
     if (!ossl_mlkem768_decap(out_shared_secret2, out_ciphertext,
-                             OSSL_MLKEM768_CIPHERTEXT_BYTES, &private_key))
-        return 4;
+                             OSSL_MLKEM768_CIPHERTEXT_BYTES, &private_key, mlkem_ctx)) {
+        ret = -4;
+        goto end;
+    }
     if (!TEST_int_eq(memcmp(out_shared_secret, out_shared_secret2,
-                            OSSL_MLKEM768_SHARED_SECRET_BYTES), 0))
-        return 5;
+                            OSSL_MLKEM768_SHARED_SECRET_BYTES), 0)) {
+        ret = -5;
+        goto end;
+    }
     /* so far so good, now a quick negative test by breaking the ciphertext */
     out_ciphertext[0]++;
     ossl_mlkem768_decap(out_shared_secret2, out_ciphertext,
-                        OSSL_MLKEM768_CIPHERTEXT_BYTES, &private_key);
+                        OSSL_MLKEM768_CIPHERTEXT_BYTES, &private_key, mlkem_ctx);
     /* Mismatch is goodness */
     if (!TEST_int_ne(memcmp(out_shared_secret, out_shared_secret2,
                             OSSL_MLKEM768_SHARED_SECRET_BYTES), 0))
-        return 6;
+        ret = -6;
+
+end:
+    ossl_mlkem_ctx_free(mlkem_ctx);
 #endif
-    return 0;
+    return ret;
 }


### PR DESCRIPTION
This PR removes the static and incorrectly initialized (no `libctx` usage) performance-enhancing EVP_MD cache structures in favour of a new `mlkem_ctx` structure correctly initialized using `libctx`. 

Also added (and now passing) is the EVP-level test originally contributed in https://github.com/openssl/openssl/pull/25403.

API change impact is significant, performance impact not insignificant (mostly has to do with correct placement of ctx object in provider context): In general, during review please check/provide feedback on "TODO" comments.